### PR TITLE
Correctly create urls for talking with the unleash server.

### DIFF
--- a/unleash_client/__init__.py
+++ b/unleash_client/__init__.py
@@ -1,5 +1,7 @@
 import logging
 
+from urllib.parse import urljoin
+
 from .clients import Client, DummyClient
 from .io import UrlFetcher, FileFetcher
 
@@ -23,7 +25,7 @@ def client(
     elif url.startswith('file:///'):
         fetch = FileFetcher(url[8:])
     elif url.startswith('http://') or url.startswith('https://'):
-        fetch = UrlFetcher(url + '/api/client/features', refresh_interval, headers)
+        fetch = UrlFetcher(urljoin(url, '/api/client/features'), refresh_interval, headers)
     else:
         log.error("Unexpected unleash client url scheme: %r", url)
         raise ValueError(url)

--- a/unleash_client/clients.py
+++ b/unleash_client/clients.py
@@ -1,6 +1,7 @@
 import time
 
 import logging
+from urllib.parse import urljoin
 
 from .strategy import DEFAULT_STRATEGIES
 from .io import UrlFetcher, Reporter
@@ -35,7 +36,7 @@ class Client:
         self.instance_id = instance_id or name_instance()
 
         self.strategies = strategies
-        features_url = url + '/api/client/features'
+        features_url = urljoin(url, '/api/client/features')
         self.fetch = fetch or UrlFetcher(features_url, refresh_interval, self._headers)
         self.defs = {}
         self.features = {}
@@ -43,7 +44,7 @@ class Client:
         if not disable_metrics:
             self.reporter = Reporter(
                 self,
-                url + '/api/client/metrics',
+                urljoin(url, '/api/client/metrics'),
                 metrics_interval,
                 self._headers,
                 clock=clock,


### PR DESCRIPTION
This makes the client more tolerant with partially malformed urls that might be used when configuring it.
(For example, avoid double slashes).