### PR TITLE
Ignore invalid contexts.

### DIFF
--- a/unleash_client/clients.py
+++ b/unleash_client/clients.py
@@ -60,7 +60,10 @@ class Client:
             self.features = {t.feature['name']: t for t in ts}
         return self.features.get(name, lambda *al, **kw: False)
 
-    def enabled(self, name, context):
+    def enabled(self, name, context = {}):
+        if not isinstance(context, dict):
+            log.error("Ignoring context parameter, as it is not a dictionary: %r", context)
+            context = {}
         try:
             return self.get(name)(context)
         finally:


### PR DESCRIPTION
As well as make the context parameter optional.

Unleash client should tolerate someone throwing an invalid parameter, though log an error message.